### PR TITLE
0209 percentile bug

### DIFF
--- a/work/COVIDvu-predict.ipynb
+++ b/work/COVIDvu-predict.ipynb
@@ -75,7 +75,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "COUNTRY_NAME = 'United Kingdom'"
+    "COUNTRY_NAME = 'China'"
    ]
   },
   {
@@ -110,6 +110,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from covidvu.utils import autoReloadCode; autoReloadCode()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "nTune = 20\n",
     "nSamples = 50\n",
     "nChains = 2\n",
@@ -121,6 +130,21 @@
    "metadata": {},
    "source": [
     "This may take some time..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "predictions = predictLogisticGrowth(\n",
+    "    countryTrainIndex=0,\n",
+    "    nTune=nTune,\n",
+    "    nSamples=nSamples,\n",
+    "    nChains=nChains,\n",
+    "    nBurn=nBurn,\n",
+    ")"
    ]
   },
   {
@@ -205,6 +229,38 @@
     "ax.legend(loc='upper left')\n",
     "plt.savefig(f'./figures/{COUNTRY_NAME.strip()}_log_prediction.png', bbox_inches='tight')"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = vis.plot()\n",
+    "trace = predictions['trace']\n",
+    "tPredict = np.arange(len(predictions['predictionsMeanTS'].index))\n",
+    "for i in range(len(trace)):\n",
+    "    carryingCap = 10 ** trace['logCarryingCapacity'][i]\n",
+    "\n",
+    "    ax.plot(tPredict, carryingCap / (\n",
+    "            1 + np.exp(-1.0 * trace['growthRate'][i] * (tPredict - trace['midPoint'][i]))),\n",
+    "            '-k', alpha=0.1\n",
+    "           )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",

--- a/work/COVIDvu-predict.ipynb
+++ b/work/COVIDvu-predict.ipynb
@@ -119,10 +119,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nTune = 20\n",
-    "nSamples = 50\n",
+    "nTune = 200\n",
+    "nSamples = 500\n",
     "nChains = 2\n",
-    "nBurn = 0"
+    "nBurn = 100"
    ]
   },
   {
@@ -211,8 +211,8 @@
     "np.log10(predictions['predictionsMeanTS']+1).plot(ax=ax, linestyle='-.', color='black', label='Mean Prediction')\n",
     "np.log10(predictions['countryTSClean']+1).plot(ax=ax, marker='o', color='green', label='Data clean')\n",
     "ax.fill_between(predictions['predictionsMeanTS'].index,\n",
-    "                np.log(predictions['predictionsPercentilesTS'][0][0]+1),\n",
-    "                np.log(predictions['predictionsPercentilesTS'][0][1]+1),\n",
+    "                np.log10(predictions['predictionsPercentilesTS'][0][0]+1),\n",
+    "                np.log10(predictions['predictionsPercentilesTS'][0][1]+1),\n",
     "                color='red',\n",
     "                alpha=0.1, \n",
     "                label = r\"95% CI\");\n",
@@ -229,38 +229,6 @@
     "ax.legend(loc='upper left')\n",
     "plt.savefig(f'./figures/{COUNTRY_NAME.strip()}_log_prediction.png', bbox_inches='tight')"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig, ax = vis.plot()\n",
-    "trace = predictions['trace']\n",
-    "tPredict = np.arange(len(predictions['predictionsMeanTS'].index))\n",
-    "for i in range(len(trace)):\n",
-    "    carryingCap = 10 ** trace['logCarryingCapacity'][i]\n",
-    "\n",
-    "    ax.plot(tPredict, carryingCap / (\n",
-    "            1 + np.exp(-1.0 * trace['growthRate'][i] * (tPredict - trace['midPoint'][i]))),\n",
-    "            '-k', alpha=0.1\n",
-    "           )"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",

--- a/work/COVIDvu-predict.ipynb
+++ b/work/COVIDvu-predict.ipynb
@@ -101,16 +101,9 @@
     "- `nTune = 200`\n",
     "- `nSamples = 500`\n",
     "- `nChains = 2`\n",
-    "- `nBurn = 100`"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from covidvu.utils import autoReloadCode; autoReloadCode()"
+    "- `nBurn = 100`\n",
+    "\n",
+    "(Running on Jupyter notebooks is for demonstration purposes only, and will be much slower than running `python covidvu/predict.py <i>`)"
    ]
   },
   {
@@ -130,21 +123,6 @@
    "metadata": {},
    "source": [
     "This may take some time..."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "predictions = predictLogisticGrowth(\n",
-    "    countryTrainIndex=0,\n",
-    "    nTune=nTune,\n",
-    "    nSamples=nSamples,\n",
-    "    nChains=nChains,\n",
-    "    nBurn=nBurn,\n",
-    ")"
    ]
   },
   {
@@ -255,7 +233,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/work/covidvu/predict.py
+++ b/work/covidvu/predict.py
@@ -93,7 +93,7 @@ def _getPredictionsFromPosteriorSamples(t,
 
     tPredict = np.arange(len(t) + nDaysPredict)
 
-    predictions = np.zeros((len(t)+nDaysPredict, nSamples))
+    predictions = np.zeros((len(t)+nDaysPredict, nSamples - nBurn))
 
     for i in range(len(trace[nBurn:])):
         carryingCap = 10 ** trace['logCarryingCapacity'][nBurn+i]
@@ -248,7 +248,7 @@ def predictLogisticGrowth(countryTrainIndex: int        = None,
                     'countryTSClean':           countryTSClean,
                     'countryName':              countryName,
                  }
-    set_trace()
+
     return prediction
 
 

--- a/work/covidvu/predict.py
+++ b/work/covidvu/predict.py
@@ -9,9 +9,8 @@ from os.path import join
 from covidvu.pipeline.vujson import parseCSSE
 from covidvu.pipeline.vujson import _dumpJSON
 from covidvu.pipeline.vujson import SITE_DATA
-from covidvu.pipeline.vujson import JH_CSSE_FILE_CONFIRMED
-from covidvu.pipeline.vujson import JH_CSSE_FILE_DEATHS
-from covidvu.pipeline.vujson import JH_CSSE_FILE_RECOVERED
+
+from pdb import set_trace
 
 N_SAMPLES        = 500
 N_TUNE           = 200
@@ -249,6 +248,7 @@ def predictLogisticGrowth(countryTrainIndex: int        = None,
                     'countryTSClean':           countryTSClean,
                     'countryName':              countryName,
                  }
+    set_trace()
     return prediction
 
 

--- a/work/covidvu/predict.py
+++ b/work/covidvu/predict.py
@@ -10,7 +10,6 @@ from covidvu.pipeline.vujson import parseCSSE
 from covidvu.pipeline.vujson import _dumpJSON
 from covidvu.pipeline.vujson import SITE_DATA
 
-from pdb import set_trace
 
 N_SAMPLES        = 500
 N_TUNE           = 200
@@ -28,8 +27,6 @@ PREDICTIONS_PERCENTILES = (
                                 (2.5, 97.5),
                                 (25, 75),
                           )
-
-from pdb import set_trace
 
 
 def _getCountryToTrain(countryTrainIndex, confirmedCases):


### PR DESCRIPTION
Posterior samples were being saved into an array which was pre-allocated to be too large, causing the aggregate statistics to become skewed downwards.

Also, when running make sure that the first line reads
```
WARNING (theano.tensor.blas): Using NumPy C-API based implementation for BLAS functions.
```
In notebooks `pymc3` uses a python-based implementation which is x200 slower than when you run it in raw python.

**Consequence**: It should be straightforward to run this for as many countries as we like.