### PR TITLE
Census data notebook for downloading and parsing

### DIFF
--- a/work/census-data.ipynb
+++ b/work/census-data.ipynb
@@ -291,24 +291,6 @@
    "source": [
     "rmtree(join('./site-data', 'census-data', 'idbzip'))"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!pwd"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!ls site-data/cen"
-   ]
   }
  ],
  "metadata": {

--- a/work/census-data.ipynb
+++ b/work/census-data.ipynb
@@ -161,7 +161,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "populationWorld.to_csv(join('site-data', 'populationCountries.csv'), index=False)"
+    "populationWorld.to_csv(join('site-data','census-data', 'populationCountries.csv'), index=False)"
    ]
   },
   {
@@ -245,7 +245,69 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ageSexWorld.to_csv(join('site-data', 'ageSexCountries.csv'), index=False)"
+    "ageSexWorld.to_csv(join('site-data','census-data', 'ageSexCountries.csv'), index=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Clean up"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from os import remove\n",
+    "from shutil import rmtree"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "remove(join('./site-data', 'census-data.zip'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "remove('../.wget-hsts')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rmtree(join('./site-data', 'census-data', 'idbzip'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pwd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ls site-data/cen"
    ]
   }
  ],
@@ -265,7 +327,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.1"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,

--- a/work/census-data.ipynb
+++ b/work/census-data.ipynb
@@ -1,0 +1,273 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Parse International Census Data from United States Census Bureau \n",
+    "\n",
+    "Dataset gateway is [here](https://www.census.gov/data-tools/demo/idb/informationGateway.php), and the full dataset can be downloaded [here](https://www2.census.gov/programs-surveys/international-programs/about/idb/idbzip.zip), see [here](https://www.census.gov/programs-surveys/international-programs/about/idb/faq.html#par_textimage_2).\n",
+    "\n",
+    "See also Google's [COVID-19 public datasets](https://console.cloud.google.com/marketplace/details/bigquery-public-datasets/covid19-public-data-program?_ga=2.118817228.-458258001.1586199431&pli=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from os.path import join"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Download census data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%sx wget -O ./site-data/census-data.zip https://www2.census.gov/programs-surveys/international-programs/about/idb/idbzip.zip"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%sx unzip ./site-data/census-data.zip -d ./site-data/census-data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get population size of every country of the world"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "censusPath = join('site-data', 'census-data', 'idbzip')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "countryCodes = pd.read_csv(join(censusPath, 'IDBextCTYS.txt'), sep='|', \n",
+    "            names=['countryCode','countryName','landArea'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "countryCodes.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "population = pd.read_csv(join(censusPath, 'IDBext001.txt'), sep='|', \n",
+    "                         names=['countryCode', 'year', 'midYearPopulation'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "currentYear = pd.Timestamp.today().year"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "populationCurrent = population[population.year == currentYear]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "populationCurrent.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "populationWorld = pd.merge(countryCodes, populationCurrent, on = 'countryCode', how='left')\n",
+    "populationWorld = populationWorld[['countryCode', 'countryName', 'midYearPopulation']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert populationWorld['midYearPopulation'].isnull().sum() == 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "populationWorld.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "populationWorld.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "populationWorld.to_csv(join('site-data', 'populationCountries.csv'), index=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get age & sex distribution of every country of the world"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ageSex = pd.read_csv(join(censusPath, 'IDBext094.txt'), sep='|', \n",
+    "           names=['countryCode', 'year', 'totalFlag', 'startAge', 'isOpen', 'endAge', \n",
+    "                  'midYearPopulationAll', 'midYearPopulationMale', 'midYearPopulationFemale'])\n",
+    "\n",
+    "ageSex = ageSex[(ageSex.year == currentYear) & (ageSex.totalFlag == 'A')]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ageSexWorld = pd.merge(countryCodes, ageSex, on = 'countryCode', how='left')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ageSexWorld = ageSexWorld[['countryCode', 'countryName', 'startAge', 'isOpen', \n",
+    "                                 'endAge', 'midYearPopulationMale', 'midYearPopulationFemale']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert ageSexWorld['midYearPopulationMale'].isnull().sum() == 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert ageSexWorld['midYearPopulationFemale'].isnull().sum() == 0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ageSexWorld.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ageSexWorld.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ageSexWorld.to_csv(join('site-data', 'ageSexCountries.csv'), index=False)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
Generates `./site-data/census-data` with files `ageSexCountries.csv` and `populationCountries.csv`. I have run this on my mini-lab and the data are there. It's a one-shot thing, so I haven't modularized this, but happy to do so if that would work better.

Linked to #409 but doesn't close the issue. Need to integrate this into `virustrack.json`.